### PR TITLE
update listenForEvents to add a timeout to the read operation

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -223,16 +223,29 @@ document.addEventListener('DOMContentLoaded', () => { // set up all our listener
                 });
             }
     
-            while (true) {
-                const { value, done } = await reader.read();
-                if (done) {
-                    if (buffer.length) {
-                      buffer = processBuffer(buffer);
+            const TIMEOUT_MS = 15000; // Set timeout duration (15 seconds)
+
+            try {
+                while (true) {
+                    const timeoutPromise = new Promise((_, reject) =>
+                        setTimeout(() => reject(new Error("Read operation timed out")), TIMEOUT_MS)
+                    );
+
+                    const { value, done } = await Promise.race([reader.read(), timeoutPromise]);
+                    if (done) {
+                        if (buffer.length) {
+                        buffer = processBuffer(buffer);
+                        }
+                        console.log("\n\nStream complete\n");
+                        return concatenatedText;
                     }
-                    return concatenatedText;
-                  }
-                  buffer += decoder.decode(value)
-                  buffer = processBuffer(buffer);
+                    buffer += decoder.decode(value)
+                    buffer = processBuffer(buffer);
+                }
+            }
+            catch (error) {
+                console.error("Loop exited due to:", error.message);
+                return concatenatedText;
             }
         } catch (error) {
             console.error('Error listening for events:', error);


### PR DESCRIPTION
I added a timeout per-read-operation as the timing of the overall operation is hard to estimate and varies significantly from run to run. If there's no event for 15 seconds, the read operation throws an error and the function returns. 